### PR TITLE
feat: reduce minimum release age default to 3 days

### DIFF
--- a/.github/workflows/qb-security.yml
+++ b/.github/workflows/qb-security.yml
@@ -30,9 +30,9 @@ on:
         type: boolean
         default: true
       js-minimum-release-age-minutes:
-        description: 'Required quarantine period for newly published package versions (pnpm `minimumReleaseAge`). Default 10080 (7 days). Set to 0 to disable.'
+        description: 'Required quarantine period for newly published package versions (pnpm `minimumReleaseAge`). Default 4320 (3 days). Set to 0 to disable.'
         type: number
-        default: 10080
+        default: 4320
       js-allow-builds:
         description: |
           Newline- or comma-separated list of packages allowed to run install/lifecycle scripts.


### PR DESCRIPTION
## Summary
- Changes `js-minimum-release-age-minutes` default from `10080` (7 days) to `4320` (3 days)
- This is now the **single source of truth** for the default — the underlying `js-supply-chain-check` action (see QuickBirdEng/actions#33) no longer has its own default

## Why
Consolidates the default into one place (the workflow) rather than duplicating it across the action input, the shell script fallback, and the workflow.

## Test plan
- [ ] Merge QuickBirdEng/actions#33 first (action now requires the value to be passed)
- [ ] Verify the workflow passes `4320` to the action correctly
- [ ] Spot-check a repo using `qb-security` to confirm it picks up the new default