### PR TITLE
feat: auto-load consumer TruffleHog ignore paths from .qb/security/trufflehog-ignores.yaml

### DIFF
--- a/.github/workflows/qb-security.yml
+++ b/.github/workflows/qb-security.yml
@@ -131,9 +131,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Merge TruffleHog exclude paths
+        id: merge-excludes
+        uses: QuickBirdEng/actions/trufflehog-merge-excludes@main
+        with:
+          base-exclude-paths: ${{ inputs.trufflehog-exclude-paths }}
+
       - name: TruffleHog Secret Scan
         uses: QuickBirdEng/actions/trufflehog-scan@main
         with:
           base: ${{ inputs.trufflehog-base }}
-          exclude-paths: ${{ inputs.trufflehog-exclude-paths }}
+          exclude-paths: ${{ steps.merge-excludes.outputs.file }}
           include-paths: ${{ inputs.trufflehog-include-paths }}


### PR DESCRIPTION
## Summary

- The `trufflehog-scan` job in `qb-security.yml` now automatically reads `.qb/security/trufflehog-ignores.yaml` from the consumer repo and merges its `paths` section with any caller-provided `trufflehog-exclude-paths`
- Uses the new `QuickBirdEng/actions/trufflehog-merge-excludes@main` composite action
- Repos without the file are completely unaffected (no-op)
- `acknowledged_findings` in the consumer file are not applied in PR scans (nightly only); a `::notice::` is emitted to inform

## Consumer file format

```yaml
# .qb/security/trufflehog-ignores.yaml
paths:
  - test/fixtures/**
  - docs/fake-creds.txt
acknowledged_findings:
  - { commit: "abc123", path: some/file.ts }
```

## Depends on

Requires `QuickBirdEng/actions#43` (trufflehog-merge-excludes action) to be merged first.

## Test plan

- [ ] Merge actions#43 first
- [ ] Add `.qb/security/trufflehog-ignores.yaml` to a test repo and trigger a security scan — confirm the "Merge TruffleHog exclude paths" step logs the pattern count
- [ ] Repos without the file show no behavior change