### PR TITLE
Wire trufflehog-filter-findings into qb-security PR scan

### DIFF
--- a/.github/workflows/qb-security.yml
+++ b/.github/workflows/qb-security.yml
@@ -138,8 +138,19 @@ jobs:
           base-exclude-paths: ${{ inputs.trufflehog-exclude-paths }}
 
       - name: TruffleHog Secret Scan
+        id: trufflehog
         uses: QuickBirdEng/actions/trufflehog-scan@main
         with:
           base: ${{ inputs.trufflehog-base }}
           exclude-paths: ${{ steps.merge-excludes.outputs.file }}
           include-paths: ${{ inputs.trufflehog-include-paths }}
+          annotations: 'false'
+          output-file: ${{ runner.temp }}/trufflehog-findings.json
+        continue-on-error: true
+
+      - name: Filter acknowledged findings and annotate
+        uses: QuickBirdEng/actions/trufflehog-filter-findings@main
+        with:
+          findings-file: ${{ runner.temp }}/trufflehog-findings.json
+          scan-outcome: ${{ steps.trufflehog.outcome }}
+          fail-on-found: ${{ inputs.fail-on-found }}


### PR DESCRIPTION
## Summary

- TruffleHog scan step now runs with `annotations: 'false'` and `output-file` to capture raw JSONL
- New `Filter acknowledged findings and annotate` step (uses `trufflehog-filter-findings@main`) applies `acknowledged_findings` from the consumer's `.qb/security/trufflehog-ignores.yaml` before emitting inline annotations
- `fail-on-found` is now properly wired to the TruffleHog scan path
- No existing inputs changed

Depends on: QuickBirdEng/actions#44

## Test plan

- [ ] PR with a fixture secret acknowledged in `.qb/security/trufflehog-ignores.yaml` passes the scan
- [ ] PR with an unacknowledged secret still fails with an inline annotation