### PR TITLE
Exclude OneSignal location module from iOS builds by default (opt-in to enable)

### DIFF
--- a/.github/workflows/flutter-deploy.yml
+++ b/.github/workflows/flutter-deploy.yml
@@ -45,6 +45,10 @@ on:
         description: "Create and finalize a Sentry release after build. Should be enabled for production-like releases (study, production) only."
         type: boolean
         default: false
+      enable-onesignal-location:
+        description: "Include OneSignal's location module in the iOS build. Defaults to false, so the location module is excluded (avoids the ITMS-90683 location purpose-string warning). Set to true only for apps that actually use OneSignal location."
+        type: boolean
+        default: false
 
   workflow_dispatch:
     inputs:
@@ -137,6 +141,8 @@ jobs:
   ios-publish:
     runs-on: [self-hosted, macOS]
     needs: [generate-build-number, ios-name-suffix-generation]
+    env:
+      ONESIGNAL_DISABLE_LOCATION: ${{ !inputs.enable-onesignal-location && 'true' || '' }}
     steps:
       - uses: QuickBirdEng/actions/checkout-ssh@main
         with:

--- a/.github/workflows/flutter-release.yml
+++ b/.github/workflows/flutter-release.yml
@@ -54,6 +54,10 @@ on:
         description: "Create and finalize a Sentry release after build. Should be enabled for production-like releases (study, production) only."
         type: boolean
         default: false
+      enable-onesignal-location:
+        description: "Include OneSignal's location module in the iOS build. Defaults to false, so the location module is excluded (avoids the ITMS-90683 location purpose-string warning). Set to true only for apps that actually use OneSignal location."
+        type: boolean
+        default: false
   workflow_dispatch:
 
 concurrency:
@@ -203,6 +207,8 @@ jobs:
   ios-publish:
     runs-on: [self-hosted, macOS]
     needs: [generate-build-number, lint, test, ios-name-suffix-generation]
+    env:
+      ONESIGNAL_DISABLE_LOCATION: ${{ !inputs.enable-onesignal-location && 'true' || '' }}
     steps:
       - uses: QuickBirdEng/actions/checkout-ssh@main
         with:


### PR DESCRIPTION
## What

Adds an `enable-onesignal-location` input (default **false**) to `flutter-release.yml` and `flutter-deploy.yml`. The `ios-publish` job derives `ONESIGNAL_DISABLE_LOCATION` from it:

```yaml
ONESIGNAL_DISABLE_LOCATION: ${{ !inputs.enable-onesignal-location && 'true' || '' }}
```

So **by default the OneSignal location module is excluded** from iOS builds. Apps that actually use OneSignal location opt back in with `enable-onesignal-location: true`.

## Why

OneSignal's location module references `requestAlwaysAuthorization`, so App Store Connect flags **ITMS-90683 (missing `NSLocationAlwaysAndWhenInUseUsageDescription`)** even for apps that never use location.`onesignal_flutter` (≥ 5.6.0) reads `ONESIGNAL_DISABLE_LOCATION` in its SPM manifest to drop the `OneSignalLocation` product, removing the location API references at the source. Excluding it by default is the safe, privacy-friendly choice for the common case.