### PR TITLE
fix: stop HAProxy ingress controller reload loop from unstable log_target_list

### DIFF
--- a/.github/workflows/k8s-setup-azure.yml
+++ b/.github/workflows/k8s-setup-azure.yml
@@ -64,8 +64,6 @@ jobs:
               defaults-config-snippet: |
                 log global
                 option httplog
-              global-config-snippet: |
-                log stdout format raw local0 info
           EOF
       - name: Setup Global Configuration
         run: |
@@ -77,6 +75,11 @@ jobs:
             name: haproxy-global
             namespace: haproxy-controller
           spec:
+            log_target_list:
+              - address: stdout
+                format: raw
+                facility: local0
+                level: info
             ssl_options:
               default_bind_ciphers: ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256
               default_bind_ciphersuites: TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384

--- a/.github/workflows/k8s-setup-ionos.yml
+++ b/.github/workflows/k8s-setup-ionos.yml
@@ -67,8 +67,6 @@ jobs:
               defaults-config-snippet: |
                 log global
                 option httplog
-              global-config-snippet: |
-                log stdout format raw local0 info
           EOF
       - name: Setup Global Configuration
         run: |
@@ -80,6 +78,11 @@ jobs:
             name: haproxy-global
             namespace: haproxy-controller
           spec:
+            log_target_list:
+              - address: stdout
+                format: raw
+                facility: local0
+                level: info
             ssl_options:
               default_bind_ciphers: ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256
               default_bind_ciphersuites: TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384

--- a/.github/workflows/k8s-setup-otc.yml
+++ b/.github/workflows/k8s-setup-otc.yml
@@ -76,8 +76,6 @@ jobs:
               defaults-config-snippet: |
                 log global
                 option httplog
-              global-config-snippet: |
-                log stdout format raw local0 info
           EOF
       - name: Setup Global Configuration
         run: |
@@ -89,6 +87,11 @@ jobs:
             name: haproxy-global
             namespace: haproxy-controller
           spec:
+            log_target_list:
+              - address: stdout
+                format: raw
+                facility: local0
+                level: info
             ssl_options:
               default_bind_ciphers: ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256
               default_bind_ciphersuites: TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384


### PR DESCRIPTION
## Summary

Moves the HAProxy ingress controller's log configuration out of the Helm `global-config-snippet` and into the `Global` custom resource's `log_target_list`, across all three provider setup workflows (Azure, Ionos, OTC). The CR becomes the single source of truth for logging, which is the intended mechanism whenever `cr-global` is in use.

## Status: hygiene change, no longer an active bug fix

**Original motivation (obsolete):** on controller 3.2.9, the dual-path config (snippet + CR without `log_target_list`) triggered a constant reload loop (`Global config updated: LogTargetList` every ~30s), which also degraded ingress allow-list enforcement. That reload bug was properly fixed upstream in controller **3.2.11** (haproxytech/kubernetes-ingress commit `4fdff2a`, "prevent continuous reloads on default log config"). Since these workflows install the latest chart (no version pin), any new bootstrap gets a fixed controller regardless of this PR. The separate allow-list enforcement gap mentioned in the original description was root-caused independently and is tracked upstream in haproxytech/kubernetes-ingress#832.

**Remaining value of this PR:**
1. **Re-run protection** — the equivalent change is already applied live on the `apellis-analysis-pipeline` cluster (2026-07-12). Without this PR, any re-run of `k8s-deploy-base.yml` silently reverts that cluster's Helm values back to the dual-path config.
2. **Config correctness** — declaring log targets on the `Global` CR while `cr-global` is set avoids the documented pitfall where the CR silently overrides snippet/ConfigMap log settings (haproxytech/kubernetes-ingress#633).

Reasonable to merge as tidy-up; equally reasonable to close if minimizing churn in this shared repo is preferred.

## Test plan
- [x] YAML validated for all three edited files
- [x] Equivalent change applied live to apellis-analysis-pipeline (2026-07-12); logging to stdout confirmed working, no reload churn